### PR TITLE
Wait for child stream close events

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -38,22 +38,50 @@ function run({executable, args, stdOutput, errOutput, stdin = null, options}, do
     return P.reject(new Error('An errOutput function must be provided'));
   }
 
+  const eventOrder = [];
+
   // Create the child process
   const child = spawn(executable, args, options);
 
   // Create a promise that will be resolved when the child process has exited.
   // The promise will be rejected if error event is raised for the child process
-  const exited = new P((resolve, reject) => {
-    child.once('exit', (code, signal) => resolve(asExitCode(code, signal)));
+  const childExited = new P((resolve, reject) => {
+    child.once('exit', (code, signal) => {
+      eventOrder.push('child process exit');
+      resolve(asExitCode(code, signal));
+    });
     child.once('error', err => reject(new Error('Error from child process:' + err.toString())));
   });
 
-  // Create a promise that will be resolved when the child process stdio streams have all closed.
+  // Create a promise that will be resolved when the child process has closed.
+  // This is documented as occuring after the stdio streams of the child process have been closed,
+  // so is in some way redundant with the above.
   // The promise will be rejected if an error event is raised on the child's streams
-  const closed = new P((resolve, reject) => {
-    child.once('close', (code, signal) => resolve(asExitCode(code, signal)));
+  const childClosed = new P((resolve) => {
+    child.once('close', (code, signal) => {
+      eventOrder.push('child process close');
+      resolve(asExitCode(code, signal));
+    });
+  });
+
+  // Create a promise that will be resolved when the child process stdout stream has closed.
+  // The promise will be rejected if an error event is raised on the stdout stream
+  const childStdoutClosed = new P((resolve, reject) => {
+    child.stdout.once('close', () => {
+      eventOrder.push('child stdout close');
+      resolve();
+    });
     child.stdout.once('error', err => reject(new Error('Error from child stdout:' + err.toString())));
-    child.stdin.once('error', err => reject(new Error('Error from child stdin:' + err.toString())));
+  });
+
+  // Create a promise that will be resolved when the child process stdout stream has closed.
+  // The promise will be rejected if an error event is raised on the stdout stream
+  const childStderrClosed = new P((resolve, reject) => {
+    child.stderr.once('close', () => {
+      eventOrder.push('child stderr close');
+      resolve();
+    });
+    child.stderr.once('error', err => reject(new Error('Error from child stderr:' + err.toString())));
   });
 
   // When any data is output by the child, call the corresponding `output` function with the data.
@@ -83,16 +111,28 @@ function run({executable, args, stdOutput, errOutput, stdin = null, options}, do
     stdin.once('readable', onProcessStdinReadable);
   }
 
+  let exitCode;
+  let closeCode;
+
   // Wait for both process exit and stdio streams closed, order of which is not guaranteed.
   // When both have happened, call the supplied `done` callback.
-  return P.all([exited, closed])
+  return P.all([childExited, childClosed])
   .then(results => {
-    const [exitCode, closeCode] = results;
+    [exitCode, closeCode] = results;
     if (stdin) {
       stdin.removeListener('readable', onProcessStdinReadable);
       stdin.removeListener('end', onProcessStdinEnd);
     }
-    return {exitCode, closeCode};
+  })
+  .then(() => {
+    return P.all([childStdoutClosed, childStderrClosed])
+    .timeout(20)
+    .catch(P.TimeoutError, err => {
+      console.error('\nChild stdio closed events not received', err.toString());
+    });
+  })
+  .then(() => {
+    return {exitCode, closeCode, eventOrder};
   })
   .catch(err => {
     console.error('\n' + err.toString());

--- a/test/spec.js
+++ b/test/spec.js
@@ -33,7 +33,8 @@ function testExitCodeWith(parent, code) {
 
     const [executable, ...args] = cmdline.split(' ');
     return runner.run({executable, args, stdOutput: output, errOutput: output})
-    .then(status => {
+    .then(s => {
+      const status = _.omit(s, 'eventOrder');
       return expect(status).to.deep.equal({ exitCode: code, closeCode: code });
     });
   });
@@ -61,7 +62,8 @@ function testWithBlaster(parent, numLines, delay=0, options = {env: process.env}
 
     const [executable, ...args] = cmdline.split(' ');
     return runner.run({executable, args, stdOutput: output, errOutput: output, options})
-    .then(status => {
+    .then(s => {
+      const status = _.omit(s, 'eventOrder');
       expect(status).to.deep.equal({ exitCode: 0, closeCode: 0 });
       const lines = chunks.toArray().join('').split('\n');
       if (/teeouterr/.test(parent)) {


### PR DESCRIPTION
Previously we waited just for the child process closed event,
which was documented to be emitted when the streams where closed.
With this commit, we wait for all of events.

This is whistling in the dark, hoping for some magic that will fix
the occasional truncated logs problem.

This commit also includes some instrumentation to show the order
that these events are received. The typical order seems to be:

1. "child stderr close"
2. "child stdout close"
3. "child process exit"
4. "child process close"

However, sometimes the order is:

1. "child stderr close"
2. "child process exit"
3. "child process close"
4. "child stdout close"

If log truncation happened only with child stdout, I might rationalize
the this ordering of events could be the smoking gun for the bug. But we have
been observing log truncation when cranking up the `debug` log output, which
has been using `stderr`.