### PR TITLE
Report exit code as final progress message from mergeouterr

### DIFF
--- a/bin/mergeouterr.js
+++ b/bin/mergeouterr.js
@@ -65,16 +65,25 @@ if (progress) {
   progressTimer = setInterval(displayProgress, progressSecs*1000);
 }
 
+function stopProgress() {
+  clearInterval(progressTimer);
+  if (exitCode == null || exitCode != 0) {
+    process.stderr.write(`${progress} exited with code ${exitCode} with ${numBytesWritten} bytes written\n`);
+  } else {
+    process.stderr.write(`${progress} completed succesfully with ${numBytesWritten} bytes written\n`);
+  }
+}
+
 P.any([runnerCompleted, fileWriteFailed])
-.then(() => progressTimer ? clearInterval(progressTimer) : null)
+.then(() => progressTimer ? stopProgress() : null)
 .then(() => bufferedFileStream.finish())
-.catch(err => console.error('\nmergeouterr failed with err:' + err.toString() + err.stack))
+.catch(err => process.stderr.write('\nmergeouterr failed with err:' + err.toString() + err.stack))
 .finally(() => {
   if (exitCode == null) {
-    console.error('\nFailed to set exitCode!');
+    process.stderr.write('\nFailed to set exitCode!');
     exitCode = 1;
   } else if (exitCode != 0) {
-    console.error(`\nChild ${executable} exited with error status: ${exitCode}`);
+    process.stderr.write(`\nChild ${executable} exited with error status: ${exitCode}`);
   }
   process.exit(exitCode);
 });

--- a/testers/exitwithcode.js
+++ b/testers/exitwithcode.js
@@ -1,7 +1,8 @@
 #! /usr/bin/env node
 'use strict';
 
-const [nodepath, scriptpath, code] = process.argv;
+const [nodepath, scriptpath, code, delay] = process.argv;
 const exitCode = parseInt(code==undefined ? '1' : code, 10);
+const delayMillis = parseFloat(delay==undefined ? '0.0' : delay) * 1000;
 console.log(`${nodepath} ${scriptpath} exiting with code: ${exitCode}`);
-process.exit(exitCode);
+setTimeout(() => process.exit(exitCode), delayMillis);


### PR DESCRIPTION
@mhfrantz When using `mergeouterr` with the progress messages, it will now output a final message with the child status code and the number of bytes of input received. This might give us more info on the cause of truncated logs.